### PR TITLE
Fix mount matrix sysfs file name

### DIFF
--- a/common.h
+++ b/common.h
@@ -44,7 +44,7 @@
 #define DEVICE_AVAIL_FREQ_PATH	BASE_PATH "sampling_frequency_available"
 #define ILLUMINATION_CALIBPATH	BASE_PATH "in_illuminance_calibscale"
 #define SENSOR_CALIB_BIAS_PATH	BASE_PATH "in_%s_calibbias"
-#define MOUNTING_MATRIX_PATH	BASE_PATH "mounting_matrix"
+#define MOUNTING_MATRIX_PATH	BASE_PATH "mount_matrix"
 #define MOUNTING_MATRIX_PATH_2	BASE_PATH "in_accel_mount_matrix"
 #define MOUNTING_MATRIX_PATH_3	BASE_PATH "in_magn_mount_matrix"
 


### PR DESCRIPTION
Hello there,

I found that the sysfs file name for the mount matrix was not as expected, so I did a quick adjustment.

Cheers
Martin